### PR TITLE
Emit empty data when TapReporter catch data

### DIFF
--- a/lib/reporter/TapReporter.js
+++ b/lib/reporter/TapReporter.js
@@ -11,6 +11,8 @@ class TapReporter extends Reporter {
   }
   setChildProc(child) {
     // Do nothing
+    child.stdout.on('data', () => {process.stdout.emit('data', '')});
+    child.stderr.on('data', () => {process.stderr.emit('data', '')});
   }
   reportFailure(name) {
     console.log(`not ok ${name}`);

--- a/test/core/lib/reporter/TapReporter.js
+++ b/test/core/lib/reporter/TapReporter.js
@@ -32,11 +32,17 @@ reporter.reportSuccess('hogefuga');
 
 const child = {
   stdout: {
+    on: (type, func) => {
+      assert(type === 'data');
+    },
     pipe: (obj) => {
       assert.ifError('Should not be reached here');
     }
   },
   stderr: {
+    on: (type, func) => {
+      assert(type === 'data');
+    },
     pipe: (obj) => {
       assert.ifError('Should not be reached here');
     }


### PR DESCRIPTION
some coverage tool like `nyc` need to catch stdout data...
if child process does not emit 'data', `nyc` stops forever