### PR TITLE
listupFiles: fix resolve path to build file paths

### DIFF
--- a/lib/listupFiles.js
+++ b/lib/listupFiles.js
@@ -14,7 +14,7 @@ module.exports = function listupFiles(dir, extention) {
   let files = [];
   const testDir = fs.readdirSync(dir);
   testDir.forEach((file) => {
-    file = `${dir}/${file}`;
+    file = path.join(dir, file);
     if (fs.statSync(file).isDirectory()) {
       files = files.concat(listupFiles(file, extention));
     } else {

--- a/test/core/lib/listupFiles.js
+++ b/test/core/lib/listupFiles.js
@@ -3,14 +3,14 @@ const listupFiles = require(`${process.cwd()}/lib/listupFiles`);
 
 const lists = listupFiles('./test/fixture', '.js');
 assert(lists.length === 6);
-assert(lists.indexOf('./test/fixture/test/a.js') !== -1);
-assert(lists.indexOf('./test/fixture/test/aaa/bbb/ccc/b.js') !== -1);
-assert(lists.indexOf('./test/fixture/test/aaa/bbb/c.js') !== -1);
-assert(lists.indexOf('./test/fixture/test/aaa/bbb/c.test.js') !== -1);
+assert(lists.indexOf('test/fixture/test/a.js') !== -1);
+assert(lists.indexOf('test/fixture/test/aaa/bbb/ccc/b.js') !== -1);
+assert(lists.indexOf('test/fixture/test/aaa/bbb/c.js') !== -1);
+assert(lists.indexOf('test/fixture/test/aaa/bbb/c.test.js') !== -1);
 
-const listTestJsFiles = listupFiles('./test/fixture', '.test.js');
+const listTestJsFiles = listupFiles('test/fixture', '.test.js');
 assert(listTestJsFiles.length === 1);
-assert(listTestJsFiles.indexOf('./test/fixture/test/aaa/bbb/c.test.js') !== -1);
+assert(listTestJsFiles.indexOf('test/fixture/test/aaa/bbb/c.test.js') !== -1);
 
 assert.throws(() => {
   listupFiles('./test/fixture');
@@ -19,4 +19,3 @@ assert.throws(() => {
 assert.throws(() => {
   listupFiles(null, '.js');
 }, /dir should be string/ );
-


### PR DESCRIPTION
Minor tweaks to listupFiles. Now no need to care about the `path.seq`:

```js
const lists = listupFiles('./test/fixture', '.js');
const lists = listupFiles('./test/fixture/', '.js');
```