### PR TITLE
Abort unhandledRejection when Promise does not handle exceptions.

### DIFF
--- a/lib/abortPromiseException.js
+++ b/lib/abortPromiseException.js
@@ -1,0 +1,3 @@
+process.on('unhandledRejection', (e) => {
+  throw e;
+});

--- a/lib/eater.js
+++ b/lib/eater.js
@@ -1,5 +1,6 @@
 'use strict';
 const cp = require('child_process');
+const path = require('path');
 const listupFiles = require('./listupFiles');
 const arraysToArgs = require('./arraysToArgs');
 const EventEmitter = require('events').EventEmitter;
@@ -29,6 +30,7 @@ class Eater extends EventEmitter {
 
   nextTest(file) {
     const args = arraysToArgs(this.requires, 'require');
+    args.push('--require', path.join(__dirname, 'abortPromiseException'));
     const child = cp.fork(file, {silent: true, execArgv: args});
     let hasErr = false;
     this.reporter.setChildProc(child);

--- a/test/core/promises/testPromiseRejectionHandled.js
+++ b/test/core/promises/testPromiseRejectionHandled.js
@@ -1,0 +1,18 @@
+const assert = require('power-assert');
+
+function testRejectPromise() {
+  return Promise.reject(new Error('Error Promise'));
+}
+const promise = testRejectPromise();
+setTimeout(() => {promise.catch(); }, 100);
+process.on('uncaughtException', (e) => {
+  assert(e.message === 'Error Promise');
+});
+
+process.on('rejectionHandled', (p) => {
+  p.catch((e) => {
+    assert(e.message === 'Error Promise');
+  });
+});
+
+

--- a/test/core/promises/testPromiseUnhandledRejection.js
+++ b/test/core/promises/testPromiseUnhandledRejection.js
@@ -1,0 +1,22 @@
+const assert = require('power-assert');
+
+function testRejectPromise() {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject(new Error('test'));
+    }, 100);
+  });
+}
+
+testRejectPromise().then(() => {
+  assert('test');
+}).catch((e) => {
+  // failure!!!!!
+  // call unhandledRejection
+  assert(e.message !== 'test');
+});
+
+process.on('uncaughtException', (e) => {
+  assert.ok(e);
+});
+


### PR DESCRIPTION
Current Node process does not abort on `unhandledRejection`.
So if developers write the following sample test code,

```javascript
const assert = require('assert');

function testRejectPromise() {
  return new Promise((resolve, reject) => {
    setTimeout(() => {
      reject(new Error('test'));
    }, 100);
  });
}

testRejectPromise().then(() => {
  assert('test');
});
```

eater cannot catch the error.

workaround is here.

```js
const assert = require('power-assert');

function testRejectPromise() {
  return new Promise((resolve, reject) => {
    setTimeout(() => {
      reject(new Error('test'));
    }, 100);
  });
}

testRejectPromise().then(() => {
  assert('test');
});

process.on('unhandledRejection', (e) => {
   console.error(e);
});
```

After merging this PR, eater can handle `unhandledRejection` when promise reject an exception.
