### PR TITLE
Remove unnecessary 'must-call' dependency from production

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,5 +1,0 @@
-const mustCall = require('must-call');
-
-module.exports = {
-  mustCall: mustCall
-};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,5 +1,4 @@
 'use strict';
-const helper = require('./helper');
 
 class Runner {
   static test(message, check) {


### PR DESCRIPTION
Fixes `Error: Cannot find module 'must-call'`.

```
> eater test.js

Test File Num : 1
Testing... : test.js
module.js:440
    throw err;
    ^

Error: Cannot find module 'must-call'
    at Function.Module._resolveFilename (module.js:438:15)
    at Function.Module._load (module.js:386:25)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/path/to/node_modules/eater/lib/helper.js:1:80)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
✗ failure:  test.js
npm ERR! Test failed.  See above for more details.
```
