### PR TITLE
Run subtest sequentially

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,18 +1,54 @@
 'use strict';
+const EventEmitter = require('events').EventEmitter;
+const colo = require('colo');
+
+const runEmitter = new EventEmitter();
 
 class Runner {
+
   static test(message, check) {
-    process.send && process.send({ type: 'testname', testName: message });
-    const checkPromise = new Promise(check);
+    Runner.tasks.push({ message: message, check: check });
+    if (!Runner.eated) {
+      process.nextTick(Runner.eat);
+      Runner.eated = true;
+    }
+  }
+
+  static nextTest() {
+    if (Runner.tasks.length === 0) {
+      return;
+    }
+    const task = Runner.tasks.shift();
+    const checkPromise = new Promise(task.check);
     checkPromise.then((v) => {
-      process.send && process.send({ type: 'success', testName: message });
+      process.send && process.send({ type: 'success', testName: task.message });
+      Runner.finishedTasks.push(task.message);
+      runEmitter.emit('next');
     }).catch((e) => {
       if (e && e.stack) console.error(`${e.stack}`);
-      else console.error(`${e}`);
+      else console.error(`${colo.red.bold('Failed message: ')}${e}`);
 
-      process.send && process.send({ type: 'failure', testName: message });
+      process.send && process.send({ type: 'failure', testName: task.message });
+      Runner.finishedTasks.push(task.message);
+      runEmitter.emit('next');
     });
   }
+
+  static eat() {
+    Runner.taskCount = Runner.tasks.length;
+    runEmitter.on('next', Runner.nextTest);
+    runEmitter.emit('next');
+    process.on('exit', (code) => {
+      if (Runner.finishedTasks.length < Runner.taskCount) {
+        console.error(colo.red.bold('Pending test exists, but process exit'));
+      }
+    });
+  }
+  
 }
+
+Runner.tasks = [];
+Runner.taskCount = 0;
+Runner.finishedTasks = [];
 
 module.exports = Runner;

--- a/test/core/bin/eater/failed-pend-test.js
+++ b/test/core/bin/eater/failed-pend-test.js
@@ -1,0 +1,8 @@
+const cp = require('child_process');
+const assert = require('power-assert');
+
+const result = cp.spawnSync(`${process.cwd()}/bin/eater.js`, ["test/fixture/failed-pend-test.js"]);
+
+assert(result.stderr.toString().match(/Pending test exists, but process exit/));
+
+

--- a/test/core/lib/runner/tester.js
+++ b/test/core/lib/runner/tester.js
@@ -6,4 +6,3 @@ test('assert truthy', (done) => {
   done();
 });
 
-

--- a/test/core/lib/runner/testseq.js
+++ b/test/core/lib/runner/testseq.js
@@ -1,0 +1,29 @@
+const test = require(`${process.cwd()}/lib/runner`).test;
+const assert = require('power-assert');
+const mustCall = require('must-call');
+
+test('assert truthy', (done) => {
+  console.log('assert truthy');
+  assert(true);
+  done();
+});
+
+
+test('assert truthy async', (done) => {
+  setTimeout(mustCall(() => {
+    console.log('assert truthy async');
+    assert(true); 
+    done();
+  }), 2000);
+});
+
+
+test('assert truthy async2', (done, fail) => {
+  setTimeout(mustCall(() => {
+    console.log('assert truthy async2');
+    assert(true); 
+    done();
+  }), 1000);
+});
+
+

--- a/test/fixture/failed-pend-test.js
+++ b/test/fixture/failed-pend-test.js
@@ -1,0 +1,18 @@
+const test = require(`${process.cwd()}/lib/runner`).test;
+const assert = require('power-assert');
+const mustCall = require('must-call');
+
+test('assert truthy', (done) => {
+  assert(true);
+  // not call done, the test goes pending...
+});
+
+
+test('assert truthy async', (done) => {
+  setTimeout(mustCall(() => {
+    console.log('assert truthy async');
+    assert(true); 
+    done();
+  }), 2000);
+});
+

--- a/test/fixture/failedRunner.js
+++ b/test/fixture/failedRunner.js
@@ -1,7 +1,6 @@
 const test = require(`${process.cwd()}/lib/runner`).test;
 const assert = require('power-assert');
 
-test('assert falsy', (done) => {
-  assert(false);
+test('assert falsy', (done, fail) => {
+  fail('foo bar buz');
 });
-


### PR DESCRIPTION
before this PR, all subtests are parallel. so you can get this weird problem.

```js
const test = require('eater/runner').test;

test('some async test 1', (done) => {
  setTimeout(() => {
    assert('foo' == 'foo');
    done();
  }, 2000);
});

test('some async test 2', (done) => {
  setTimeout(() => {
    assert('foo' == 'foo');
    done();
  }, 1000);
});

test('some async test 3', (done) => {
  setTimeout(() => {
    assert('foo' == 'foo');
    done();
  }, 500);
});
```

then

```
✓ some async test3
✓ some async test2
✓ some async test1
```

this result is unclear.
my PR will change this result to

```
✓ some async test1
✓ some async test2
✓ some async test3
```

if you call `done` function then go to next test.