### PR TITLE
remove Eater.prototype.args

### DIFF
--- a/lib/eater.js
+++ b/lib/eater.js
@@ -21,7 +21,6 @@ class Eater extends EventEmitter {
     }
     this.fileNum = this.files.length;
     this.requires = options.requires || [];
-    this.args = options.args || [];
     this.finishedFiles = [];
     this.errors = {};
     this.hasAnyError = false;


### PR DESCRIPTION
`Eater.prototype.args` is unused.