### PR TITLE
fix(runner): Inherit process.env child process

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -46,7 +46,11 @@ class Runner {
 
     const task = Runner.tasks[next];
     Runner.report({type: 'testname', testName: task.message});
-    const child = forkTest(process.argv[1], {silent: true, env: {EATER_SUBTEST: '' + next}});
+    const child = forkTest(
+      process.argv[1], {
+        silent: true,
+        env: Object.assign(process.env, {EATER_SUBTEST: '' + next})
+      });
     child.on('success', (out) => {
 
       Runner.report({type: 'success', testName: task.message, out});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "npm-run-all test:* lint",
     "test:core": "node bin/eater.js --dir test/core",
     "test:runner": "node bin/eater.js --dir test/runner",
+    "test:env": "NODE_ENV=test node bin/eater.js --dir test/env",
     "test:babel": "node bin/eater.js --dir test/babel",
     "cov": "nyc npm-run-all test:core test:runner",
     "report": "nyc report --reporter=text-lcov",

--- a/test/env/test_process_env.js
+++ b/test/env/test_process_env.js
@@ -1,0 +1,11 @@
+const test = require(`${process.cwd()}/lib/runner`).test;
+const assert = require('power-assert');
+const mustCall = require('must-call');
+const ENV = 'test';
+
+assert(process.env.NODE_ENV === ENV)
+
+test('assert process.env.NODE_ENV is test', () => {
+  assert(process.env.NODE_ENV === ENV)
+});
+


### PR DESCRIPTION
when eater process use `NODE_ENV=test`, eater ignore the process.env.
This PR fixes the situation.

